### PR TITLE
Turn off react/require-default-props rule.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ module.exports = {
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md
     'react/jsx-key': 'error',
 
+    // Prefer to use ES2015 default params for functional components.
+    'react/require-default-props': 'off'
+
     // This rule will warn when it encounters a reference to an identifier that has not yet been declared.
     // https://eslint.org/docs/rules/no-use-before-define
     'no-use-before-define': [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@festicket/eslint-config",
-  "version": "1.1.4",
+  "version": "1.1.3",
   "description": "Festicket's ESLint config, extending AirBnB",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@festicket/eslint-config",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Festicket's ESLint config, extending AirBnB",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Remove the ESLint rule - react/require-default-props as we want to move towards using ES2015 default params for functional components and defaultProps as a static property when using class components.